### PR TITLE
types: add support for TS 4.7 exports handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,17 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./single": {
+      "types": "./single/index.d.ts",
       "import": "./single/index.mjs",
       "require": "./single/index.js"
     },
     "./secure": {
+      "types": "./secure/index.d.ts",
       "import": "./secure/index.mjs",
       "require": "./secure/index.js"
     },


### PR DESCRIPTION
Hi @lukeed, thanks for the awesome package!

In Typescript 4.7, there was [a new mode added](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/#esm-nodejs) to support the package.json `exports` keyword. With this mode enabled, TS can [no longer find](https://github.com/microsoft/TypeScript/issues/49160) the type declarations for `uid` (even when the root module specifier, rather than `uid/single` or `uid/secure`, is used). After going through the TS docs, I believe this is proper fix.

Thanks!